### PR TITLE
fix getRange switch case values

### DIFF
--- a/src/SparkFunADXL313.cpp
+++ b/src/SparkFunADXL313.cpp
@@ -151,16 +151,16 @@ float ADXL313::getRange() {
 	byte range = (_b & 0b00000011);
 	float range_val;
 	switch (range) {
-		case ADXL313_RANGE_05_G:
+		case 0:
 			range_val = 0.5;
 			break;
-		case ADXL313_RANGE_1_G:
+		case 1:
 			range_val = 1.0;
 			break;
-		case ADXL313_RANGE_2_G:
+		case 2:
 			range_val = 2.0;
 			break;
-		case ADXL313_RANGE_4_G:
+		case 3:
 			range_val = 4.0;
 			break;
 	}


### PR DESCRIPTION
The range of the accelerometer is determined by the last two bits of the DATA_FORMAT register. Table 16 of the datasheet shows

- 00 - 0.5 g
- 01 - 1.0 g
- 10 - 2.0 g
- 11 - 4.0 g

As numbers, those are 0, 1, 2, 3.  The old switch case was comparing 1,2,3,4.

Might also be fixed by changing what ADXL313_RANGE_05_G,etc defines to?